### PR TITLE
fix: quiz assign multiple, remove teacher calendar and admin data management

### DIFF
--- a/src/components/Sidebar.vue
+++ b/src/components/Sidebar.vue
@@ -14,7 +14,7 @@ defineOptions({ name: 'Sidebar' })
 // TYPES
 interface Props {
   isActive: boolean
-  activeSection?: 'home' | 'quizzes' | 'calendar' | 'courses' | 'archived'
+  activeSection?: 'home' | 'quizzes' | 'courses' | 'archived'
 }
 type ImportedQuestion = {
   id: number
@@ -50,7 +50,6 @@ defineEmits<{
   'join-class': []
   'nav-home': []
   'nav-quizzes': []
-  'nav-calendar': []
   'nav-archived': []
   'nav-archived-courses': []
   'nav-archived-classes': []
@@ -81,7 +80,6 @@ const isCoursesActive = computed(() => {
 const isHomeActive = computed(() => route.name === 'home')
 const activeSection = computed(() => props.activeSection)
 const isQuizzesActive = computed(() => activeSection.value === 'quizzes')
-const isCalendarActive = computed(() => activeSection.value === 'calendar')
 const isArchivedActive = computed(() => activeSection.value === 'archived')
 const isTeacher = computed(() => auth.userRole === 'teacher')
 const myClasses = computed(() => classesStore.myClasses)
@@ -258,19 +256,6 @@ async function handleImport(file: File) {
             >
               <i class="fas fa-clipboard-list w-5"></i>
               <span class="ml-3">Quizzes</span>
-            </button>
-          </li>
-
-          <li v-if="isTeacher">
-            <button
-              @click="$emit('nav-calendar')"
-              class="w-full flex items-center px-3 py-2.5 rounded-lg text-sm font-medium transition-all duration-200"
-              :class="isCalendarActive
-                ? 'bg-blue-50 text-blue-700 shadow-sm'
-                : 'text-gray-700 hover:bg-gray-50'"
-            >
-              <i class="fas fa-calendar-alt w-5"></i>
-              <span class="ml-3">Calendar</span>
             </button>
           </li>
 

--- a/src/components/admin/AdminSidebar.vue
+++ b/src/components/admin/AdminSidebar.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import { ref, computed, watch } from 'vue'
-import { Home, Users, BookOpenCheck, Settings, Database, BarChart2, Archive, ChevronDown, Fingerprint } from 'lucide-vue-next'
+import { Home, Users, BookOpenCheck, Settings, BarChart2, Archive, ChevronDown, Fingerprint } from 'lucide-vue-next'
 import { useRoute } from 'vue-router'
 import { useAuthStore } from '@/stores/authStore'
 
@@ -113,25 +113,6 @@ const toggleArchived = () => {
             ]"
           />
           Quiz Settings
-        </router-link>
-
-        <!-- Data Management -->
-        <router-link
-          to="/admin/data"
-          :class="[
-            'flex items-center px-2 py-3 text-sm font-medium rounded-md cursor-pointer transition-all sidebar-item group',
-            route.name === 'admin-data'
-              ? 'text-blue-600 bg-blue-50'
-              : 'text-gray-600 hover:text-blue-600 hover:bg-blue-50'
-          ]"
-        >
-          <Database
-            :class="[
-              'w-5 h-5 mr-3 transition-all duration-200 sidebar-icon',
-              route.name === 'admin-data' ? 'text-blue-500' : 'text-gray-400 group-hover:text-blue-500'
-            ]"
-          />
-          Data Management
         </router-link>
 
         <!-- Analytics -->

--- a/src/components/quiz/QuizAssign.vue
+++ b/src/components/quiz/QuizAssign.vue
@@ -56,6 +56,9 @@ const options = reactive({
 
 // LIFECYCLE
 onMounted(async () => {
+  // Capture initial assigned sections before any reactive changes (like pushing to classes) trigger the watcher
+  const initialStoreAssigned = [...(quizzesStore.currentQuiz.assignedSections || [])]
+
   sectionsStore.loadArchivedSectionsFromStorage()
 
   await coursesStore.fetchTeacherCourses()
@@ -234,14 +237,13 @@ onMounted(async () => {
     }
   })
 
-  const storeAssigned = quizzesStore.currentQuiz.assignedSections || []
   const metaAssigned = (meta && Array.isArray((meta as any).assignedSections)) 
       ? (meta as any).assignedSections 
       : []
 
   const fallbackClass = (meta && (meta as any).class) || ''
 
-  const combinedAssigned = new Set([...storeAssigned, ...metaAssigned, fallbackClass].filter(Boolean))
+  const combinedAssigned = new Set([...initialStoreAssigned, ...metaAssigned, fallbackClass].filter(Boolean))
 
   const effectiveAssignedSections = Array.from(combinedAssigned)
 

--- a/src/components/teacher/TeacherQuiz.vue
+++ b/src/components/teacher/TeacherQuiz.vue
@@ -32,6 +32,20 @@ const router = useRouter()
 const quizzesStore = useQuizzesStore()
 const sectionsStore = useSectionsStore()
 
+const getPrimarySection = (quiz: TeacherQuizItem) => {
+  if (Array.isArray(quiz.assignedSections) && quiz.assignedSections.length > 0) return String(quiz.assignedSections[0])
+  return quiz.class || ''
+}
+
+const getSectionLabel = (quiz: TeacherQuizItem) => {
+  if (Array.isArray(quiz.assignedSections) && quiz.assignedSections.length > 0) {
+    const arr = quiz.assignedSections
+    if (arr.length === 1) return String(arr[0])
+    return `${String(arr[0])} (+${arr.length - 1} more)`
+  }
+  return quiz.class || ''
+}
+
 // PROPS
 const props = withDefaults(defineProps<Props>(), {
   hideAppHeader: false,
@@ -108,7 +122,7 @@ const openQuizInBuilder = async (quiz: TeacherQuizItem) => {
   await quizzesStore.loadQuizForEditingAsync(quiz.id)
   router.push({
     name: 'quiz-builder',
-    params: { id: quiz.class || 'default' },
+    params: { id: getPrimarySection(quiz) || 'default' },
     query: {
       archivedContext: props.archivedContextType || undefined,
       sectionId:
@@ -192,7 +206,9 @@ const getSubmissionStats = (quiz: TeacherQuizItem) => {
   const submitted = quizzesStore.getQuizUniqueSubmitterCount(quiz.id)
   const coursesStore = useCoursesStore()
 
-  const quizSection = quiz.class?.trim().toLowerCase() ?? ''
+  const quizSection = (Array.isArray(quiz.assignedSections) && quiz.assignedSections.length > 0
+    ? String(quiz.assignedSections[0])
+    : quiz.class || '').trim().toLowerCase() ?? ''
   const quizSubject = quiz.subject?.trim().toLowerCase() ?? ''
 
   let matchingCourse = coursesStore.rawTeacherCourses.find(
@@ -210,7 +226,9 @@ const getSubmissionStats = (quiz: TeacherQuizItem) => {
     ? (matchingCourse.students || 0)
     : (() => {
 
-        const name = (quiz.class || '').trim()
+        const name = ((Array.isArray(quiz.assignedSections) && quiz.assignedSections.length > 0)
+          ? String(quiz.assignedSections[0])
+          : (quiz.class || '')).trim()
         if (!name) return quiz.total || 0
 
         const matchedSections = sectionsStore.allSections.filter(s => (s.name || '').trim() === name)
@@ -442,8 +460,8 @@ const formatDueDate = (dateStr: string) => {
               <div class="flex-1 min-w-0">
                 <div class="text-base leading-relaxed">
                   <span class="font-semibold text-blue-700">{{ quiz.subject }}</span>
-                  <span v-if="quiz.class" class="text-gray-500 text-sm ml-2">
-                    ({{ quiz.class }})
+                  <span v-if="getSectionLabel(quiz)" class="text-gray-500 text-sm ml-2">
+                    ({{ getSectionLabel(quiz) }})
                   </span>
                 </div>
               </div>
@@ -509,7 +527,7 @@ const formatDueDate = (dateStr: string) => {
                   </span>
                 </div>
                 <div class="text-base font-semibold" :class="quiz.status === 'draft' ? 'text-slate-800' : 'text-gray-900'">{{ quiz.title }}</div>
-                <div class="text-sm" :class="quiz.status === 'draft' ? 'text-slate-600' : 'text-gray-600'">{{ quiz.subject }}</div>
+                <div class="text-sm" :class="quiz.status === 'draft' ? 'text-slate-600' : 'text-gray-600'">{{ quiz.subject }}<span v-if="getSectionLabel(quiz)" class="text-gray-500 ml-2">({{ getSectionLabel(quiz) }})</span></div>
                 <div v-if="quiz.status === 'draft'" class="mt-3">
                   <button v-if="!quiz.archived" class="flex items-center gap-2 text-sm font-medium text-blue-600 hover:text-blue-700 transition-colors cursor-pointer">
                     <i class="fas fa-edit"></i>

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -108,11 +108,6 @@ const router = createRouter({
           component: () => import('../components/admin/AdminQuizSettings.vue'),
         },
         {
-          path: 'data',
-          name: 'admin-data',
-          component: () => import('../components/admin/AdminDataManagement.vue'),
-        },
-        {
           path: 'analytics',
           name: 'admin-analytics',
           component: () => import('../components/admin/AdminAnalytics.vue'),

--- a/src/stores/quizzesStore.ts
+++ b/src/stores/quizzesStore.ts
@@ -580,13 +580,20 @@ export const useQuizzesStore = defineStore('quizzes', () => {
       const allSeedQuizzes = Object.values(teacherQuizzesByUser.value).flat()
       const seedQuiz = allSeedQuizzes.find(q => q.id === id)
 
+      const derivedAssignedSections = Array.isArray(currentQuiz.assignedSections) && currentQuiz.assignedSections.length > 0
+        ? [...currentQuiz.assignedSections]
+        : (seedQuiz && Array.isArray(seedQuiz.assignedSections) && seedQuiz.assignedSections.length > 0
+          ? [...seedQuiz.assignedSections]
+          : (seedQuiz && seedQuiz.class ? [seedQuiz.class] : []))
+
       const quizItem: TeacherQuizItem = {
         id,
         title: currentQuiz.title,
         subject: currentQuiz.subject,
         description: currentQuiz.description,
         dueDate: seedQuiz ? seedQuiz.dueDate : payloadTemplate.dueAt,
-        class: seedQuiz ? seedQuiz.class : '',
+        class: (derivedAssignedSections && derivedAssignedSections.length > 0) ? String(derivedAssignedSections[0]) : (seedQuiz ? seedQuiz.class || '' : ''),
+        assignedSections: derivedAssignedSections,
         submitted: seedQuiz ? seedQuiz.submitted : 0,
         total: seedQuiz ? seedQuiz.total : 0,
         color: seedQuiz ? seedQuiz.color : 'blue',
@@ -594,7 +601,9 @@ export const useQuizzesStore = defineStore('quizzes', () => {
         questions: JSON.parse(JSON.stringify(currentQuiz.questions)),
         createdAt: seedQuiz ? seedQuiz.createdAt : new Date().toISOString(),
         updatedAt: new Date().toISOString(),
-        ownerUsername: username
+        ownerUsername: username,
+        timeLimit: seedQuiz && seedQuiz.timeLimit ? seedQuiz.timeLimit : (currentQuiz.timeLimit || undefined),
+        maxAttempts: seedQuiz && typeof seedQuiz.maxAttempts === 'number' ? seedQuiz.maxAttempts : undefined
       }
 
       currentQuiz.id = quizItem.id
@@ -700,6 +709,7 @@ export const useQuizzesStore = defineStore('quizzes', () => {
       if (payload.maxAttempts != null) {
         seedQuiz.maxAttempts = payload.maxAttempts
       }
+      saveQuizzesToStorage()
     }
   }
 
@@ -807,6 +817,13 @@ export const useQuizzesStore = defineStore('quizzes', () => {
           currentQuiz.subject = course?.name || detail.courseName || (detail.course && detail.course.name) || ''
           currentQuiz.description = detail.description || ''
           currentQuiz.timeLimit = detail.timeLimitMinutes ? `${detail.timeLimitMinutes} min` : ''
+          
+          // Load assignedSections from the stored quiz data
+          const storedQuiz = myTeacherQuizzes.value.find(q => q.id === quizId)
+          currentQuiz.assignedSections = storedQuiz && Array.isArray(storedQuiz.assignedSections)
+            ? [...storedQuiz.assignedSections]
+            : (storedQuiz?.class ? [storedQuiz.class] : [])
+          
           const rawQs = Array.isArray(detail.questions) ? detail.questions : []
           currentQuiz.questions = rawQs.map(mapApiQuestionToFrontend)
           currentQuiz.currentQuestionIndex = currentQuiz.questions.length > 0 ? 0 : -1
@@ -832,7 +849,7 @@ export const useQuizzesStore = defineStore('quizzes', () => {
   }
 
   function getAllQuizzes(): TeacherQuizItem[] {
-    return []
+    return loadQuizzesFromStorage()
   }
 
   function loadQuizzesFromStorage(): TeacherQuizItem[] {

--- a/src/views/TeacherView.vue
+++ b/src/views/TeacherView.vue
@@ -7,7 +7,6 @@ import { useCoursesStore } from '@/stores/coursesStore'
 const AppHeader = defineAsyncComponent(() => import('@/components/AppHeader.vue'))
 const Sidebar = defineAsyncComponent(() => import('@/components/Sidebar.vue'))
 const ActiveQuizzes = defineAsyncComponent(() => import('@/components/teacher/TeacherQuiz.vue'))
-const SchoolCalendar = defineAsyncComponent(() => import('@/components/SchoolCalendar.vue'))
 const TeacherClasses = defineAsyncComponent(() => import('@/components/teacher/TeacherCourses.vue'))
 const ViewAllCourses = defineAsyncComponent(() => import('@/components/ViewAllCourses.vue'))
 const ViewAllQuizzes = defineAsyncComponent(() => import('@/components/ViewAllQuizzes.vue'))
@@ -21,7 +20,7 @@ const ArchivedQuizzes = defineAsyncComponent(() => import('@/components/teacher/
 const sidebarActive = ref(false)
 const showCreateQuiz = ref(false)
 const showImport = ref(false)
-const currentSection = ref<'home' | 'quizzes' | 'calendar' | 'courses' | 'archived'>('home')
+const currentSection = ref<'home' | 'quizzes' | 'courses' | 'archived'>('home')
 const archivedView = ref<'quizzes'>('quizzes') 
 const archivedQuizzesTab = ref<'published' | 'draft'>('published')
 
@@ -73,7 +72,7 @@ watch(
   () => route.query.section,
   (val) => {
     const section = (val as string) || ''
-    if (section === 'courses' || section === 'quizzes' || section === 'calendar' || section === 'home' || section === 'archived') {
+    if (section === 'courses' || section === 'quizzes' || section === 'home' || section === 'archived') {
       currentSection.value = section as typeof currentSection.value
     }
     if (section === 'home' || !section) {
@@ -114,11 +113,6 @@ const showImportModal = () => {
 
 const navigateToQuizzes = () => {
   currentSection.value = 'quizzes'
-  closeSidebar()
-}
-
-const navigateToCalendar = () => {
-  currentSection.value = 'calendar'
   closeSidebar()
 }
 
@@ -176,7 +170,7 @@ onMounted(async () => {
   document.removeEventListener('click', handleClickOutside)
   document.addEventListener('click', handleClickOutside)
   const section = (route.query.section as string) || ''
-  if (section === 'courses' || section === 'quizzes' || section === 'calendar' || section === 'home' || section === 'archived') {
+  if (section === 'courses' || section === 'quizzes' || section === 'home' || section === 'archived') {
     currentSection.value = section as typeof currentSection.value
   }
 
@@ -209,7 +203,6 @@ onUnmounted(() => {
       @import-questions="showImportModal"
       @nav-home="navigateToHome"
       @nav-quizzes="navigateToQuizzes"
-      @nav-calendar="navigateToCalendar"
       @nav-archived="navigateToArchived"
       @nav-archived-quizzes="navigateToArchivedQuizzes"
       @nav-archived-quizzes-published="navigateToArchivedQuizzesPublished"
@@ -232,8 +225,6 @@ onUnmounted(() => {
         </div>
         <!-- Quizzes Section -->
         <ViewAllQuizzes v-else-if="currentSection === 'quizzes'" />
-        <!-- Calendar Section -->
-        <SchoolCalendar v-else-if="currentSection === 'calendar'" />
         <!-- Archived Section -->
         <div v-else-if="currentSection === 'archived'" class="space-y-6">
           <!-- ArchivedCourses - Admin-only -->


### PR DESCRIPTION
----
## Summary by Gitar

- **Enhanced quiz assignment logic:**
  - Added support for multiple assigned sections to `TeacherQuiz` and `quizzesStore` components.
  - Updated `quizzesStore` to derive `assignedSections` and persist them during editing.
- **Refined UI display:**
  - Updated `TeacherQuiz` to display primary section labels with count indicators for multiple assignments.
- **Cleanup:**
  - Removed `SchoolCalendar` component, related router entries, and `Data Management` sections from the UI.


<sub>This will update automatically on new commits.</sub>